### PR TITLE
fix a comment about GIC

### DIFF
--- a/ports_smp/cortex_a9_smp/gnu/example_build/MP_GIC.S
+++ b/ports_smp/cortex_a9_smp/gnu/example_build/MP_GIC.S
@@ -57,7 +57,7 @@ disableGIC:
 
   // Get base address of private peripheral space
   MRC     p15, 4, r0, c15, c0, 0  // Read periph base address
-  ADD     r0, r0, #0x1000         // Add the GIC offset
+  ADD     r0, r0, #0x1000         // Add the GIC Interrupt distributor offset
 
   LDR     r1, [r0]                // Read the GIC Enable Register  (ICDDCR)
   BIC     r1, r1, #0x01           // Clear bit 0, the enable bit


### PR DESCRIPTION
[1] from a cortex-a9 soc's manual:
0100—01FFh Interrupt controller interfaces
1000—1FFFh Interrupt distributor
[2] arm_cortexa9_trm_100511_0401_10_en.pdf
4.3.25 Configuration Base Address Register